### PR TITLE
Code Cleanup / Refactoring: C-Style Cast in pcsx2/R5900OpcodeImpl.cpp

### DIFF
--- a/pcsx2/R5900OpcodeImpl.cpp
+++ b/pcsx2/R5900OpcodeImpl.cpp
@@ -1081,7 +1081,6 @@ void SYSCALL()
 					addr = cpuRegs.GPR.n.a0.UL[0] + n_transfer * sizeof(t_sif_dma_transfer);
 					t_sif_dma_transfer* dmat = reinterpret_cast<t_sif_dma_transfer*>(PSM(addr));
 
-
 					BIOS_LOG("bios_%s: n_transfer=%d, size=%x, attr=%x, dest=%x, src=%x",
 							R5900::bios[cpuRegs.GPR.n.v1.UC[0]], n_transfer,
 							dmat->size, dmat->attr,

--- a/pcsx2/R5900OpcodeImpl.cpp
+++ b/pcsx2/R5900OpcodeImpl.cpp
@@ -1079,7 +1079,8 @@ void SYSCALL()
 				if (n_transfer >= 0)
 				{
 					addr = cpuRegs.GPR.n.a0.UL[0] + n_transfer * sizeof(t_sif_dma_transfer);
-					t_sif_dma_transfer* dmat = (t_sif_dma_transfer*)PSM(addr);
+					t_sif_dma_transfer* dmat = reinterpret_cast<t_sif_dma_transfer*>(PSM(addr));
+
 
 					BIOS_LOG("bios_%s: n_transfer=%d, size=%x, attr=%x, dest=%x, src=%x",
 							R5900::bios[cpuRegs.GPR.n.v1.UC[0]], n_transfer,


### PR DESCRIPTION
### Description of Changes
Changed C-Style cast to C++-Style in `pcsx2/R5900OpcodeImpl.cpp`.

### Rationale behind Changes
C++-Style casting is generally safer.

### Suggested Testing Steps
Compile and use PCSX2 as per usual.
