### PR TITLE
Code Cleanup / Refactoring: C-Style Cast in pcsx2/DEV9/DEV9.cpp

### DIFF
--- a/pcsx2/DEV9/DEV9.cpp
+++ b/pcsx2/DEV9/DEV9.cpp
@@ -130,7 +130,7 @@ s32 DEV9init()
 		}
 		else
 		{
-			dev9.eeprom = (u16*)MapViewOfFile(mapping, FILE_MAP_WRITE, 0, 0, 0);
+			dev9.eeprom = reinterpret_cast<u16*>(MapViewOfFile(mapping, FILE_MAP_WRITE, 0, 0, 0));
 
 			if (dev9.eeprom == NULL)
 			{


### PR DESCRIPTION
### Description of Changes
Changed C-Style cast to C++-Style in `pcsx2/DEV9/DEV9.cpp`

### Rationale behind Changes
C++-Style casting is generally safer.

### Suggested Testing Steps
Compile and use PCSX2 as per usual.