### PR TITLE
Code Cleanup / Refactoring: C-Style Cast in common/Image.cpp

### DIFF
--- a/common/Image.cpp
+++ b/common/Image.cpp
@@ -394,7 +394,7 @@ namespace
 
 		static void ErrorExit(j_common_ptr cinfo)
 		{
-			JPEGErrorHandler* eh = (JPEGErrorHandler*)cinfo->err;
+			JPEGErrorHandler* eh = reinterpret_cast<JPEGErrorHandler*>(cinfo->err);
 			char msg[JMSG_LENGTH_MAX];
 			eh->err.format_message(cinfo, msg);
 			Console.ErrorFmt("libjpeg fatal error: {}", msg);


### PR DESCRIPTION
### Description of Changes
Changed C-Style cast to C++-Style in `common/Image.cpp`

### Rationale behind Changes
C++-Style casting is generally safer.

### Suggested Testing Steps
Compile and use PCSX2 as per usual.